### PR TITLE
test framework: test both multicluster network scenarios at once"

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -230,27 +230,13 @@ EOF
   export CLUSTER1_KUBECONFIG="${KUBECONFIG_DIR}/${CLUSTER1_NAME}"
   export CLUSTER2_KUBECONFIG="${KUBECONFIG_DIR}/${CLUSTER2_NAME}"
   export CLUSTER3_KUBECONFIG="${KUBECONFIG_DIR}/${CLUSTER3_NAME}"
-  CLUSTER_KUBECONFIGS=("$CLUSTER1_KUBECONFIG" "$CLUSTER2_KUBECONFIG" "$CLUSTER3_KUBECONFIG")
 
   if [[ "${TOPOLOGY}" != "SINGLE_CLUSTER" ]]; then
-    for i in "${!CLUSTER_NAMES[@]}"; do
-      CLUSTERI_NAME="${CLUSTER_NAMES[$i]}"
-      CLUSTERI_KUBECONFIG="${CLUSTER_KUBECONFIGS[$i]}"
-
-      for j in "${!CLUSTER_NAMES[@]}"; do
-        CLUSTERJ_NAME="${CLUSTER_NAMES[$j]}"
-        CLUSTERJ_KUBECONFIG="${CLUSTER_KUBECONFIGS[$j]}"
-
-        if [ "$j" -gt "$i" ]; then
-          DIRECT_ACCESS=0
-          if [[ "${TOPOLOGY}" == "MULTICLUSTER_SINGLE_NETWORK" ]]; then
-            DIRECT_ACCESS=1
-          fi
-
-          connect_kind_clusters "${CLUSTERI_NAME}" "${CLUSTERI_KUBECONFIG}" "${CLUSTERJ_NAME}" "${CLUSTERJ_KUBECONFIG}" "${DIRECT_ACCESS}"
-        fi
-      done
-    done
+    # Clusters 1 and 2 are on the same network
+    connect_kind_clusters "${CLUSTER1_NAME}" "${CLUSTER1_KUBECONFIG}" "${CLUSTER2_NAME}" "${CLUSTER2_KUBECONFIG}" 1
+    # Cluster 3 is on a different network but we still need to set up routing for MetalLB addresses
+    connect_kind_clusters "${CLUSTER1_NAME}" "${CLUSTER1_KUBECONFIG}" "${CLUSTER3_NAME}" "${CLUSTER3_KUBECONFIG}" 0
+    connect_kind_clusters "${CLUSTER2_NAME}" "${CLUSTER2_KUBECONFIG}" "${CLUSTER3_NAME}" "${CLUSTER3_KUBECONFIG}" 0
   fi
 }
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -52,6 +52,12 @@ endif
 
 _INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 
+# If $(INTEGRATION_TEST_NETWORKS) is set, add the networkTopology flag
+_INTEGRATION_TEST_NETWORKS ?= $(INTEGRATION_TEST_NETWORKS)
+ifneq ($(_INTEGRATION_TEST_NETWORKS),)
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.networkTopology=$(_INTEGRATION_TEST_NETWORKS)
+endif
+
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
 	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \


### PR DESCRIPTION
1. Reduces the "MULTICLUSTER_SINGLE_NETWORK" and "MULTICLUSTER_MULTINETWORK" into a single "MULTICLUSTER" topology for Prow. 
2. The `MULTICLUSTER` topology configures 3 clusters, 2 on the same network and a third on a separate network. The multicluster tests are given a `networkTopology` to match.
3. The multicluster test cases `ClusterLocalTest` and `ReachabilityTest` will test all clusters passed in `istio.test.kube.config`. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
